### PR TITLE
small fix of field templates connection, so that in standalone theme all...

### DIFF
--- a/runway-framework/framework/core/admin-object.php
+++ b/runway-framework/framework/core/admin-object.php
@@ -1212,7 +1212,7 @@ if ( !defined( $runway_framework_admin ) ) {
 					}
 				}
 				
-				if(!$found_in_framework_dirs) {
+				if(!$found_in_framework_dirs && !$found_in_theme_dirs) {
 					$template_path = get_theme_root().'/'.$theme_data['Template'].'/data-types/'.$field->type.'.php';
 				}
 			}


### PR DESCRIPTION
... folder field types are connected and not missed

Noticed that if I export theme as standalone there was no font-select fields shown in admin panel